### PR TITLE
init script fix for debian systems

### DIFF
--- a/templates/jboss.init.erb
+++ b/templates/jboss.init.erb
@@ -1,11 +1,13 @@
+<% if operatingsystem == 'RedHat' or operatingsystem == 'CentOS' or operatingsystem == 'Scientific' %>
 #!/bin/sh
 # File Managed by Puppet
-<% if operatingsystem == 'RedHat' or operatingsystem == 'CentOS' or operatingsystem == 'Scientific' %>
 # jboss        Startup script for JBoss
 #
 # chkconfig: - 85 15
 # description: Jboss is an Application Server
 <% elsif operatingsystem == 'Debian' or operatingsystem == 'Ubuntu' or operatingsystem == 'Mint' %>
+#!/bin/bash
+# File Managed by Puppet
 <% end %>
 ### BEGIN INIT INFO
 # Provides:          jboss

--- a/templates/jboss6.init.erb
+++ b/templates/jboss6.init.erb
@@ -1,11 +1,13 @@
+<% if operatingsystem == 'RedHat' or operatingsystem == 'CentOS' or operatingsystem == 'Scientific' %>
 #!/bin/sh
 # File Managed by Puppet
-<% if operatingsystem == 'RedHat' or operatingsystem == 'CentOS' or operatingsystem == 'Scientific' %>
 # jboss        Startup script for JBoss
 #
 # chkconfig: - 85 15
 # description: Jboss is an Application Server
 <% elsif operatingsystem == 'Debian' or operatingsystem == 'Ubuntu' or operatingsystem == 'Mint' %>
+#!/bin/bash
+# File Managed by Puppet
 <% end %>
 ### BEGIN INIT INFO
 # Provides:          jboss

--- a/templates/jboss7.init.erb
+++ b/templates/jboss7.init.erb
@@ -1,6 +1,6 @@
+<% if operatingsystem == 'RedHat' or operatingsystem == 'CentOS' or operatingsystem == 'Scientific' %>
 #!/bin/sh
 # File Managed by Puppet
-<% if operatingsystem == 'RedHat' or operatingsystem == 'CentOS' or operatingsystem == 'Scientific' %>
 # jboss        Startup script for JBoss
 #
 # chkconfig: - 80 20
@@ -9,6 +9,8 @@
 . /etc/init.d/functions
 
 <% elsif operatingsystem == 'Debian' or operatingsystem == 'Ubuntu' or operatingsystem == 'Mint' %>
+#!/bin/bash
+# File Managed by Puppet
 # Poor man alternatives to RedHat init functions
 success () {
   echo "OK"


### PR DESCRIPTION
Hi, this pull request fixes init script looping due because of lack of `let` command in `dash` (which /bin/sh refers to)
