### PR TITLE
'create_user' should be 'createuser'

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For detailed info about the logic and usage patterns of Example42 modules read R
         }
 
         jboss::instance { 'app1':
-          create_user => false, # Default user jboss is already created by jboss class
+          createuser => false, # Default user jboss is already created by jboss class
           bindaddr    => '127.0.0.1',
           port        => '8080',
         }


### PR DESCRIPTION
The documentation refers to a `jboss::instance` param called `create_user` but it's actually `createuser` in the source:

https://github.com/example42/puppet-jboss/blob/master/manifests/instance.pp#L108
