### PR TITLE
Revert "Update init.pp"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -379,7 +379,7 @@ class jboss (
 
   $manage_file = $jboss::bool_absent ? {
     true    => 'absent',
-    default => 'file',
+    default => 'present',
   }
 
   if $jboss::bool_absent == true


### PR DESCRIPTION
This reverts commit be15b99ecb92166baf4bb4463d3c5431c7c77574.

PR #14 both broke the rspec tests and introduced this catalog
complication error:

```
Error: Parameter ensure failed on User[jboss]: Invalid value "file".
Valid values are present, absent, role.  at
/home/jhoblitt/nsa/modules/jboss/manifests/user.pp:20
Wrapped exception:
Invalid value "file". Valid values are present, absent, role.
```
