### PR TITLE
Wrong owner of JBoss directory (JBoss 5.1.0.GA from source)

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,7 +34,8 @@ class jboss::install inherits jboss {
         preextract_command  => $jboss::install_precommand,
         postextract_command => $jboss::real_install_postcommand,
         extracted_dir       => $jboss::real_created_dirname,
-        owner               => 'root',
+        owner               => $jboss::process_user,
+        group               => $jboss::process_user,
         require             => User[$jboss::process_user],
       }
 


### PR DESCRIPTION
I've encountered an issue when using the module to install JBoss 5.1.0.GA from source. The target folder /opt/jboss-5.1.0.GA gets chowned for the user jboss in

/Stage[main]/Jboss::Install/Puppi::Netinstall[netinstall_jboss]/Exec[PostExtract download in /opt]

and back to root:root in 

/Stage[main]/Jboss::Install/Puppi::Netinstall[netinstall_jboss]/Exec[Chown download in /opt]

In this case, the JBoss service fails to start, because the directory is not writable for the user jboss. I'm using Vagrant with a Precise64 box.

I've attached a simple fix that works for me. However, I'm not sure if this was the correct way to fix this.
