### PR TITLE
Change the server base directory to use the copied instance

### DIFF
--- a/templates/jboss7.init-instance.erb
+++ b/templates/jboss7.init-instance.erb
@@ -26,14 +26,14 @@ JBOSS_USER=${JBOSS_USER:-"<%= @user %>"}
 JAVAPTH=${JAVAPTH:-"/usr/local/jdk/bin"}
 
 # configuration to use
-JBOSS_CONF=${JBOSS_CONF:-"<%= @name %>"}
+JBOSS_CONF=${JBOSS_CONF:-"-Djboss.server.base.dir=<%= @name %>"}
 
 # if JBOSS_HOST specified, use -b to bind jboss services to that address
 #JBOSS_BIND_ADDR=${JBOSS_HOST:+"-b <%= @bindaddr %>"}
 JBOSS_BIND_ADDR=${JBOSS_HOST:-"-b <%= @bindaddr %>"}
 
 # define the script to use to start jboss
-JBOSSSH=${JBOSSSH:-"$JBOSS_HOME/bin/<%= scope.lookupvar('jboss::real_mode') %>.sh -Djboss.server.base.dir=$JBOSS_CONF $JBOSS_BIND_ADDR"}
+JBOSSSH=${JBOSSSH:-"$JBOSS_HOME/bin/<%= scope.lookupvar('jboss::real_mode') %>.sh $JBOSS_CONF $JBOSS_BIND_ADDR"}
 
 # Lock and Pid files
 LOCKFILE=/var/lock/jboss-<%= @name %>


### PR DESCRIPTION
Server did not start before, because the -c option specifies
a configuration xml file and not the server instance
